### PR TITLE
feat(viz-modal): auto focus text input when changing chart visualization

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -651,6 +651,14 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
     return [];
   };
 
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+        searchInputRef.current?.focus();
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
   return (
     <VizPickerLayout
       className={className}


### PR DESCRIPTION
### SUMMARY

This PR adds auto-focus in search input field when the "Change Visualization Type" modal opens. Previously, users had to manually click the input field before typing to search for chart types. By automatically focusing the input on modal open, this change streamlines the user experience during chart creation.

### BEFORE/AFTER SCREENSHOTS

#### Before:

<img width="959" height="477" alt="superset_issue2_prev" src="https://github.com/user-attachments/assets/bbb35c3f-b2d5-46f7-8f79-38213b2bb3d7" />

#### After:

<img width="1909" height="917" alt="superset_issue2_fixed" src="https://github.com/user-attachments/assets/b5fbb3e2-bac5-4097-8949-fa7ab96fbf27" />

### VIDEO DEMO

https://github.com/user-attachments/assets/e9c2c041-a395-4613-921d-eb4027c34c00

### TESTING INSTRUCTIONS

1. Open any chart in Explore view
2. Click "Change Visualization Type" button
3. Modal opens
4. Verify cursor is automatically in the search input
5. Start typing immediately without clicking

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #5 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59]( https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API