### PR TITLE
fix(sql-lab): show string values with angle brackets

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -32,6 +32,28 @@ describe('sanitizeHtml', () => {
     const sanitizedString = sanitizeHtml(htmlString);
     expect(sanitizedString).not.toContain('script');
   });
+
+  test('should sanitize common XSS attack vectors', () => {
+    // Script tag injection
+    expect(sanitizeHtml('<script>alert(1)</script>')).not.toContain('script');
+
+    // Event handler injection
+    const onclickAttack = '<div onclick="alert(1)">click me</div>';
+    expect(sanitizeHtml(onclickAttack)).not.toContain('onclick');
+
+    // JavaScript protocol
+    const jsProtocol = '<a href="javascript:alert(1)">link</a>';
+    expect(sanitizeHtml(jsProtocol)).not.toContain('javascript:');
+
+    // Iframe injection
+    const iframeAttack = '<iframe src="evil.com"></iframe>';
+    const sanitized = sanitizeHtml(iframeAttack);
+    expect(sanitized).not.toContain('iframe');
+
+    // IMG onerror
+    const imgAttack = '<img src=x onerror="alert(1)">';
+    expect(sanitizeHtml(imgAttack)).not.toContain('onerror');
+  });
 });
 
 describe('isProbablyHTML', () => {
@@ -41,6 +63,16 @@ describe('isProbablyHTML', () => {
     expect(isHTML).toBe(true);
   });
 
+  test('should detect XSS attempts as HTML and trigger sanitization', () => {
+    // These should be detected as HTML so they get sanitized
+    expect(isProbablyHTML('<script>alert(1)</script>')).toBe(true);
+    expect(isProbablyHTML('<div onclick="evil()">text</div>')).toBe(true);
+    expect(isProbablyHTML('<a href="javascript:void(0)">link</a>')).toBe(true);
+    expect(isProbablyHTML('<body onload="alert(1)">')).toBe(true);
+    expect(isProbablyHTML('<style>body{display:none}</style>')).toBe(true);
+    expect(isProbablyHTML('<html><head><title>Fake</title></head></html>')).toBe(true);
+  });
+
   test('should return false if the text does not contain HTML tags', () => {
     const plainText = 'Just a plain text';
     const isHTML = isProbablyHTML(plainText);
@@ -48,6 +80,36 @@ describe('isProbablyHTML', () => {
 
     const trickyText = 'a <= 10 and b > 10';
     expect(isProbablyHTML(trickyText)).toBe(false);
+  });
+
+  test('should return false for strings with angle brackets that are not HTML', () => {
+    // Empty angle brackets
+    expect(isProbablyHTML('<>')).toBe(false);
+
+    // Single angle bracket
+    expect(isProbablyHTML('<')).toBe(false);
+    expect(isProbablyHTML('>')).toBe(false);
+
+    // Comparison operators
+    expect(isProbablyHTML('5 < 10')).toBe(false);
+    expect(isProbablyHTML('10 > 5')).toBe(false);
+    expect(isProbablyHTML('a <= b')).toBe(false);
+    expect(isProbablyHTML('x >= y')).toBe(false);
+
+    // Generic labels/tags that don't match HTML tag patterns
+    expect(isProbablyHTML('<value>')).toBe(false);
+    expect(isProbablyHTML('<data>')).toBe(false);
+    expect(isProbablyHTML('<name>')).toBe(false);
+    expect(isProbablyHTML('<tag>')).toBe(false);
+    expect(isProbablyHTML('<foo>bar</foo>')).toBe(false);
+
+    // Mathematical expressions
+    expect(isProbablyHTML('if (x < 5 && y > 3)')).toBe(false);
+    expect(isProbablyHTML('result: <pending>')).toBe(false);
+
+    // Arrow notation
+    expect(isProbablyHTML('A -> B')).toBe(false);
+    expect(isProbablyHTML('<->')).toBe(false);
   });
 });
 
@@ -81,6 +143,28 @@ describe('safeHtmlSpan', () => {
     const plainText = 'Just a plain text';
     const result = safeHtmlSpan(plainText);
     expect(result).toEqual(plainText);
+  });
+
+  test('should return plain text for angle brackets that are not HTML (bug fix)', () => {
+    // These should NOT be treated as HTML and should be returned as-is
+    expect(safeHtmlSpan('<>')).toBe('<>');
+    expect(safeHtmlSpan('<value>')).toBe('<value>');
+    expect(safeHtmlSpan('a < b')).toBe('a < b');
+    expect(safeHtmlSpan('result: <pending>')).toBe('result: <pending>');
+  });
+
+  test('should still sanitize actual XSS attempts (security verification)', () => {
+    // These should be treated as HTML and wrapped in sanitized span
+    const xssAttempt = '<script>alert(1)</script>';
+    const result = safeHtmlSpan(xssAttempt);
+
+    // Should return a span element (not plain text)
+    expect(result).toHaveProperty('type', 'span');
+    expect(result).toHaveProperty('props.className', 'safe-html-wrapper');
+
+    // The sanitized HTML should NOT contain the script tag
+    const sanitizedHtml = (result as any).props.dangerouslySetInnerHTML.__html;
+    expect(sanitizedHtml).not.toContain('script');
   });
 });
 

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -36,7 +36,8 @@ const xssFilter = new FilterXSS({
       'muted',
     ],
   },
-  stripIgnoreTag: true,
+  stripIgnoreTag: false,
+  stripIgnoreTagBody: ['script', 'style'],
   css: false,
 });
 
@@ -54,6 +55,7 @@ export function hasHtmlTagPattern(str: string): boolean {
 export function isProbablyHTML(text: string) {
   const cleanedStr = text.trim().toLowerCase();
 
+  // Check for DOCTYPE strings only
   if (
     cleanedStr.startsWith('<!doctype html>') &&
     hasHtmlTagPattern(cleanedStr)
@@ -63,7 +65,20 @@ export function isProbablyHTML(text: string) {
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(cleanedStr, 'text/html');
-  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
+
+  // Check if DOMParser detected any element nodes
+  const hasElementNodes = Array.from(doc.body.childNodes).some(
+    ({ nodeType }) => nodeType === 1,
+  );
+
+  // If no element nodes found, it's definitely not HTML
+  if (!hasElementNodes) {
+    return false;
+  }
+
+  // DOMParser may create implicit elements for malformed content, but we want to ensure
+  // the string actually contains recognizable HTML tags
+  return hasHtmlTagPattern(cleanedStr);
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {


### PR DESCRIPTION
### SUMMARY

This PR fixes display issues in SQL Lab query results. Previously, strings containing angle brackets (< or/and >) were not shown correctly because they were interpreted as HTML. The updated rendering logic now escapes angle brackets in string values while preserving valid HTML tags, ensuring all query results display properly.

### BEFORE/AFTER SCREENSHOTS 

#### Before:

<img width="351" height="319" alt="superset_issue4_prev" src="https://github.com/user-attachments/assets/fdcfa261-f729-453b-9026-8efa0a1eebb9" />

#### After:

<img width="356" height="336" alt="superset_issue4_fixed" src="https://github.com/user-attachments/assets/6eefa9af-f273-4482-81ac-7bea1ea8fea9" />

### VIDEO DEMO

https://drive.google.com/file/d/1UgEtbMTJN1QlnOrLO1D1E4qXwPMmvk3n/view?usp=sharing

### TESTING INSTRUCTIONS

1. Open SQL -> SQL Lab
2. Execute query returning strings with angle brackets
3. Verify that values are displayed as expected
4. Some test samples:

```
Query statement:  SELECT '<hello>' AS html_string;
Query result: <hello>

Query statement: SELECT '<div><b><hello></b></div>' as html_string
Query result (in bold): <hello> 

Query statement: SELECT '<span> <o' as html_string
Query result: <o
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #7 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
