### PR TITLE
fix(tags): displays in alphabetical order

### DIFF
--- a/superset-frontend/src/components/Tags/TagsList.test.tsx
+++ b/superset-frontend/src/components/Tags/TagsList.test.tsx
@@ -42,6 +42,30 @@ const testTags = [
   },
 ];
 
+// Tags for testing alphabetical sorting
+const unsortedTags = [
+  {
+    name: 'Zebra',
+    id: 1,
+  },
+  {
+    name: 'apple',
+    id: 2,
+  },
+  {
+    name: 'Banana',
+    id: 3,
+  },
+  {
+    name: 'cherry',
+    id: 4,
+  },
+  {
+    name: 'Date',
+    id: 5,
+  },
+];
+
 const mockedProps: TagsListProps = {
   tags: testTags,
   onDelete: undefined,
@@ -74,4 +98,43 @@ test('should render 3 elements when maxTags is set to 3', async () => {
   const tagsListItems = await findAllTags();
   expect(tagsListItems).toHaveLength(3);
   expect(tagsListItems[2]).toHaveTextContent('+3...');
+});
+
+test('should sort tags alphabetically (case-insensitive)', async () => {
+  render(<TagsList tags={unsortedTags} />);
+  const tagsListItems = await findAllTags();
+  expect(tagsListItems).toHaveLength(5);
+  // Expected alphabetical order (case-insensitive): apple, Banana, cherry, Date, Zebra
+  expect(tagsListItems[0]).toHaveTextContent('apple');
+  expect(tagsListItems[1]).toHaveTextContent('Banana');
+  expect(tagsListItems[2]).toHaveTextContent('cherry');
+  expect(tagsListItems[3]).toHaveTextContent('Date');
+  expect(tagsListItems[4]).toHaveTextContent('Zebra');
+});
+
+test('should maintain alphabetical order with maxTags', async () => {
+  render(<TagsList tags={unsortedTags} maxTags={3} />);
+  const tagsListItems = await findAllTags();
+  expect(tagsListItems).toHaveLength(3);
+  // Should show first 2 alphabetically sorted tags and the +3... indicator
+  expect(tagsListItems[0]).toHaveTextContent('apple');
+  expect(tagsListItems[1]).toHaveTextContent('Banana');
+  expect(tagsListItems[2]).toHaveTextContent('+3...');
+});
+
+test('should maintain stable sort order for identical names', async () => {
+  const duplicateTags = [
+    { name: 'Tag', id: 1 },
+    { name: 'tag', id: 2 },
+    { name: 'TAG', id: 3 },
+    { name: 'TaG', id: 4 },
+  ];
+  render(<TagsList tags={duplicateTags} />);
+  const tagsListItems = await findAllTags();
+  expect(tagsListItems).toHaveLength(4);
+  // All variations of "tag" should maintain their relative order
+  expect(tagsListItems[0]).toHaveTextContent('Tag');
+  expect(tagsListItems[1]).toHaveTextContent('tag');
+  expect(tagsListItems[2]).toHaveTextContent('TAG');
+  expect(tagsListItems[3]).toHaveTextContent('TaG');
 });

--- a/superset-frontend/src/components/Tags/TagsList.tsx
+++ b/superset-frontend/src/components/Tags/TagsList.tsx
@@ -49,6 +49,15 @@ const TagsList = ({
 }: TagsListProps) => {
   const [tempMaxTags, setTempMaxTags] = useState<number | undefined>(maxTags);
 
+  // Sort tags alphabetically (case-insensitive) with memoization
+  const sortedTags = useMemo(
+    () =>
+      [...tags].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+      ),
+    [tags],
+  );
+
   const handleDelete = (index: number) => {
     onDelete?.(index);
   };
@@ -58,21 +67,23 @@ const TagsList = ({
   const collapse = () => setTempMaxTags(maxTags);
 
   const tagsIsLong: boolean | null = useMemo(
-    () => (tempMaxTags ? tags.length > tempMaxTags : null),
-    [tags.length, tempMaxTags],
+    () => (tempMaxTags ? sortedTags.length > tempMaxTags : null),
+    [sortedTags.length, tempMaxTags],
   );
 
   const extraTags: number | null = useMemo(
     () =>
-      typeof tempMaxTags === 'number' ? tags.length - tempMaxTags + 1 : null,
-    [tagsIsLong, tags.length, tempMaxTags],
+      typeof tempMaxTags === 'number'
+        ? sortedTags.length - tempMaxTags + 1
+        : null,
+    [tagsIsLong, sortedTags.length, tempMaxTags],
   );
 
   return (
     <TagsDiv className="tag-list">
       {tagsIsLong && typeof tempMaxTags === 'number' ? (
         <>
-          {tags.slice(0, tempMaxTags - 1).map((tag: TagType, index) => (
+          {sortedTags.slice(0, tempMaxTags - 1).map((tag: TagType, index) => (
             <Tag
               id={tag.id}
               key={tag.id}
@@ -82,17 +93,17 @@ const TagsList = ({
               editable={editable}
             />
           ))}
-          {tags.length > tempMaxTags ? (
+          {sortedTags.length > tempMaxTags ? (
             <Tag
               name={`+${extraTags}...`}
               onClick={expand}
-              toolTipTitle={tags.map(t => t.name).join(', ')}
+              toolTipTitle={sortedTags.map(t => t.name).join(', ')}
             />
           ) : null}
         </>
       ) : (
         <>
-          {tags.map((tag: TagType, index) => (
+          {sortedTags.map((tag: TagType, index) => (
             <Tag
               id={tag.id}
               key={tag.id}
@@ -103,7 +114,7 @@ const TagsList = ({
             />
           ))}
           {maxTags ? (
-            tags.length > maxTags ? (
+            sortedTags.length > maxTags ? (
               <Tag name="..." onClick={collapse} />
             ) : null
           ) : null}

--- a/superset/config.py
+++ b/superset/config.py
@@ -483,7 +483,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # This feature flag is used by the download feature in the dashboard view.
     # It is dependent on ENABLE_DASHBOARD_SCREENSHOT_ENDPOINT being enabled.
     "ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT": False,
-    "TAGGING_SYSTEM": False,
+    "TAGGING_SYSTEM": True,
     "SQLLAB_BACKEND_PERSISTENCE": True,
     "LISTVIEWS_DEFAULT_CARD_VIEW": False,
     # When True, this escapes HTML (rather than rendering it) in Markdown components


### PR DESCRIPTION
### SUMMARY

This PR fixes the ordering of tags in various views (dashboards, charts, saved queries). Previously, tags show up in different orders and updates on reload. This display inconsistency can confuse the users when they use tags to organize their data. By adding alphabetical (case-insensitive) sorting to tags and memoization, users can better navigate across views. 

### BEFORE/AFTER SCREENSHOTS 

#### Before:

<img width="1755" height="562" alt="superset_issue11_prev" src="https://github.com/user-attachments/assets/f5ddc09b-9fb4-414f-96ba-30b3dbb03d31" />

#### After:

<img width="1773" height="580" alt="superset_issue11_fixed" src="https://github.com/user-attachments/assets/8540498d-3461-43f5-9dbb-7f3fd0d38a3f" />

### VIDEO DEMO

https://drive.google.com/file/d/13EgcUUQifl_W7r6VYmZvgmSq6WIfAbBw/view?usp=sharing

### TESTING INSTRUCTIONS

1. Enable tagging
   - In code: superset/config.py, set TAGGING_SYSTEM to True
   - Create tags in app: Settings -> Manage: Tags
2. Add tags
   - Navigate to a tool (Dashboards, Charts, SQL: Saved Queries)
   - Under Actions, click Edit and select tags 
3. Verify in Tags section
   - Tags are sorted in alphabetical (case-insensitive)order
   - Display is consistent across different views and after page reloads

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #18 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
