### PR TITLE
fix(charts): display chart title in browser tab

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -299,3 +299,140 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     expect(formData[key]).toBeUndefined();
   });
 });
+
+describe('Document title management', () => {
+  const originalTitle = 'Original Title';
+
+  beforeEach(() => {
+    // Set a known original title before each test
+    document.title = originalTitle;
+  });
+
+  test('updates document title when chart has a name', async () => {
+    const chartName = 'My Awesome Chart';
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: chartName,
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    await waitFor(() => {
+      expect(document.title).toBe(chartName);
+    });
+  });
+
+  test('updates document title when slice name changes', async () => {
+    const initialChartName = 'Initial Chart';
+    const updatedChartName = 'Updated Chart';
+
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: initialChartName,
+      },
+    };
+
+    const { rerender } = renderWithRouter({ initialState: customState });
+
+    // Verify initial title is set
+    await waitFor(() => {
+      expect(document.title).toBe(initialChartName);
+    });
+
+    // Update the slice name
+    const updatedState = {
+      ...customState,
+      explore: {
+        ...customState.explore,
+        sliceName: updatedChartName,
+      },
+    };
+
+    // Re-render with updated state
+    rerender(
+      <MemoryRouter initialEntries={[`${defaultPath}`]}>
+        <Route path={defaultPath}>
+          <ExploreViewContainer />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    // Verify title is updated
+    await waitFor(() => {
+      expect(document.title).toBe(updatedChartName);
+    });
+  });
+
+  test('does not update document title when sliceName is null', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: null,
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Title should remain as the original
+    await waitFor(() => {
+      expect(document.title).toBe(originalTitle);
+    });
+  });
+
+  test('restores original title when component unmounts', async () => {
+    const chartName = 'Chart to be Unmounted';
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: chartName,
+      },
+    };
+
+    const { unmount } = renderWithRouter({ initialState: customState });
+
+    // Verify chart title is set
+    await waitFor(() => {
+      expect(document.title).toBe(chartName);
+    });
+
+    // Unmount the component
+    unmount();
+
+    // Verify title is restored to original or 'Superset' as fallback
+    expect(document.title).toBe(originalTitle || 'Superset');
+  });
+
+  test('restores "Superset" as title when original title was empty', async () => {
+    // Set empty original title
+    document.title = '';
+
+    const chartName = 'Temporary Chart';
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: chartName,
+      },
+    };
+
+    const { unmount } = renderWithRouter({ initialState: customState });
+
+    // Verify chart title is set
+    await waitFor(() => {
+      expect(document.title).toBe(chartName);
+    });
+
+    // Unmount the component
+    unmount();
+
+    // Verify title is restored to 'Superset' as fallback
+    expect(document.title).toBe('Superset');
+  });
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -404,6 +404,18 @@ function ExploreViewContainer(props) {
     }
   }, [isDynamicPluginLoading]);
 
+  // Update document title when chart name changes
+  useEffect(() => {
+    const originalTitle = document.title;
+    if (props.sliceName) {
+      document.title = props.sliceName;
+    }
+    // Cleanup: restore original title when component unmounts or navigating away
+    return () => {
+      document.title = originalTitle || 'Superset';
+    };
+  }, [props.sliceName]);
+
   useEffect(() => {
     const hasError = Object.values(props.controls).some(
       control =>


### PR DESCRIPTION
### SUMMARY

This PR fixes issues where the browser tab title is static. When users open a chart, the tab title does not reflect the corresponding chart name. By fixing this, charts/dashboards display the correct tab title while viewed and when a user navigates away it reverts to back to default. Users can effectively use page titles to organize and interact with Superset (e.g. tab management, browser history, bookmarks, and other features).

### BEFORE/AFTER SCREENSHOTS

#### Before:

<img width="1919" height="951" alt="superset_issue7_prev" src="https://github.com/user-attachments/assets/43feafd8-ec09-4e49-8812-5a4dfdbb3450" />

#### After:

<img width="1919" height="945" alt="superset_issue7_fixed" src="https://github.com/user-attachments/assets/672df808-85e0-486e-893c-f8db772fd9dc" />


### TESTING INSTRUCTIONS

#### Manually:

- Navigate to an existing chart in Explore view
- Verify that the browser tab title displays the corresponding chart name
- Navigate away from the chart (e.g., go to the home page)
- Verify the tab title resets to "Superset" (8088 port) or "[DEV] Superset" (9000 port)
- Repeat the same steps for dashboard instead of chart

#### Automated (Unit Tests):

```
cd superset-frontend
npm run test -- src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #10 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
