### PR TITLE
feat(dashboard/chart): confirmation modal for unsaved changes

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.test.tsx
+++ b/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import '@testing-library/jest-dom';
+import UnsavedChangesModal from './UnsavedChangesModal';
+
+describe('UnsavedChangesModal', () => {
+  const mockOnSave = jest.fn();
+  const mockOnDiscard = jest.fn();
+  const mockOnHide = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render modal when showModal is true', () => {
+    render(
+      <UnsavedChangesModal
+        showModal
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+      />,
+    );
+
+    expect(
+      screen.getByText('Save Changes?'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'You have unsaved changes. Would you like to save them before leaving?',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render modal when showModal is false', () => {
+    render(
+      <UnsavedChangesModal
+        showModal={false}
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+      />,
+    );
+
+    expect(
+      screen.queryByText('Save Changes?'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should call onSave when Save button is clicked', () => {
+    render(
+      <UnsavedChangesModal
+        showModal
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+      />,
+    );
+
+    const saveButton = screen.getByRole('button', {
+      name: /save changes/i,
+    });
+    userEvent.click(saveButton);
+
+    expect(mockOnSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onDiscard when Discard button is clicked', () => {
+    render(
+      <UnsavedChangesModal
+        showModal
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+      />,
+    );
+
+    const discardButton = screen.getByRole('button', {
+      name: /discard changes/i,
+    });
+    userEvent.click(discardButton);
+
+    expect(mockOnDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable Save button when saveDisabled is true', () => {
+    render(
+      <UnsavedChangesModal
+        showModal
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+        saveDisabled
+      />,
+    );
+
+    const saveButton = screen.getByRole('button', {
+      name: /save changes/i,
+    });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('should enable Save button when saveDisabled is false', () => {
+    render(
+      <UnsavedChangesModal
+        showModal
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+        saveDisabled={false}
+      />,
+    );
+
+    const saveButton = screen.getByRole('button', {
+      name: /save changes/i,
+    });
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('should call onHide when modal is dismissed without clicking buttons', () => {
+    render(
+      <UnsavedChangesModal
+        showModal
+        onSave={mockOnSave}
+        onDiscard={mockOnDiscard}
+        onHide={mockOnHide}
+      />,
+    );
+
+    // Find the close button (usually an X button in the modal header)
+    const closeButton = document.querySelector('.antd5-modal-close');
+    if (closeButton) {
+      userEvent.click(closeButton);
+      expect(mockOnHide).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.tsx
+++ b/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.tsx
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { t } from '@superset-ui/core';
+import Modal from 'src/components/Modal';
+import Button from 'src/components/Button';
+
+export interface UnsavedChangesModalProps {
+  showModal: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+  onHide: () => void;
+  saveDisabled?: boolean;
+}
+
+function UnsavedChangesModal({
+  showModal,
+  onSave,
+  onDiscard,
+  onHide,
+  saveDisabled = false,
+}: UnsavedChangesModalProps) {
+  const footer = (
+    <>
+      <Button key="discard" buttonStyle="secondary" onClick={onDiscard}>
+        {t('Discard changes')}
+      </Button>
+      <Button
+        key="save"
+        buttonStyle="primary"
+        onClick={onSave}
+        disabled={saveDisabled}
+      >
+        {t('Save changes')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Modal
+      show={showModal}
+      onHide={onHide}
+      title={t('Save Changes?')}
+      footer={footer}
+      hideFooter={false}
+      centered
+    >
+      <p>
+        {t(
+          'You have unsaved changes. Would you like to save them before leaving?',
+        )}
+      </p>
+    </Modal>
+  );
+}
+
+export default UnsavedChangesModal;

--- a/superset-frontend/src/components/UnsavedChangesModal/index.ts
+++ b/superset-frontend/src/components/UnsavedChangesModal/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { default } from './UnsavedChangesModal';
+export type { UnsavedChangesModalProps } from './UnsavedChangesModal';

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -44,6 +44,8 @@ import { safeStringify } from 'src/utils/safeStringify';
 import PublishedStatus from 'src/dashboard/components/PublishedStatus';
 import UndoRedoKeyListeners from 'src/dashboard/components/UndoRedoKeyListeners';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
+import UnsavedChangesModal from 'src/components/UnsavedChangesModal';
+import { useUnsavedChangesModal } from 'src/hooks/useUnsavedChangesModal';
 import {
   UNDO_LIMIT,
   SAVE_TYPE_OVERWRITE,
@@ -504,6 +506,17 @@ const Header = () => {
       ?.SUPERSET_DASHBOARD_PERIODICAL_REFRESH_WARNING_MESSAGE;
   const isEmbedded = !dashboardInfo?.userId;
 
+  // Hook for unsaved changes modal
+  const {
+    showModal: showUnsavedChangesModal,
+    handleSave: handleSaveFromModal,
+    handleDiscard: handleDiscardFromModal,
+    handleHide: handleHideModal,
+  } = useUnsavedChangesModal({
+    hasUnsavedChanges: hasUnsavedChanges && editMode,
+    onSave: overwriteDashboard,
+  });
+
   const handleOnPropertiesChange = useCallback(
     updates => {
       boundActionCreators.dashboardInfoChanged({
@@ -816,6 +829,15 @@ const Header = () => {
           dashboardId={dashboardInfo.id}
         />
       )}
+
+      <UnsavedChangesModal
+        showModal={showUnsavedChangesModal}
+        onSave={handleSaveFromModal}
+        onDiscard={handleDiscardFromModal}
+        onHide={handleHideModal}
+        saveDisabled={!hasUnsavedChanges}
+      />
+
       <Global
         styles={css`
           .antd5-menu-vertical {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -64,6 +64,8 @@ import * as exploreActions from 'src/explore/actions/exploreActions';
 import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import { useTabId } from 'src/hooks/useTabId';
 import withToasts from 'src/components/MessageToasts/withToasts';
+import UnsavedChangesModal from 'src/components/UnsavedChangesModal';
+import { useUnsavedChangesModal } from 'src/hooks/useUnsavedChangesModal';
 import ExploreChartPanel from '../ExploreChartPanel';
 import ConnectedControlPanelsContainer from '../ControlPanelsContainer';
 import SaveModal from '../SaveModal';
@@ -551,6 +553,32 @@ function ExploreViewContainer(props) {
     return errorMessage;
   }, [props.controls]);
 
+  // Hook for unsaved changes modal
+  const handleSaveChart = useCallback(async () => {
+    // Trigger save action for the chart
+    if (props.can_overwrite && props.slice) {
+      // If we can overwrite and have an existing slice, save it
+      props.actions.updateSlice(
+        props.slice,
+        props.sliceName || props.slice.slice_name,
+        [], // dashboards - empty array for no dashboard changes
+      );
+    } else {
+      // Otherwise show the save modal
+      props.actions.setSaveModalVisibility(true);
+    }
+  }, [props.actions, props.can_overwrite, props.slice, props.sliceName]);
+
+  const {
+    showModal: showUnsavedChangesModal,
+    handleSave: handleSaveFromModal,
+    handleDiscard: handleDiscardFromModal,
+    handleHide: handleHideModal,
+  } = useUnsavedChangesModal({
+    hasUnsavedChanges: chartIsStale && !props.standalone,
+    onSave: handleSaveChart,
+  });
+
   function renderChartContainer() {
     return (
       <ExploreChartPanel
@@ -722,6 +750,14 @@ function ExploreViewContainer(props) {
           dashboardId={props.dashboardId}
         />
       )}
+
+      <UnsavedChangesModal
+        showModal={showUnsavedChangesModal}
+        onSave={handleSaveFromModal}
+        onDiscard={handleDiscardFromModal}
+        onHide={handleHideModal}
+        saveDisabled={errorMessage || props.chart.chartStatus === 'loading'}
+      />
     </ExploreContainer>
   );
 }

--- a/superset-frontend/src/hooks/useUnsavedChangesModal.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesModal.ts
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+interface UseUnsavedChangesModalProps {
+  hasUnsavedChanges: boolean;
+  onSave: () => Promise<void> | void;
+}
+
+export function useUnsavedChangesModal({
+  hasUnsavedChanges,
+  onSave,
+}: UseUnsavedChangesModalProps) {
+  const history = useHistory();
+  const location = useLocation();
+  const [showModal, setShowModal] = useState(false);
+  const [pendingLocation, setPendingLocation] = useState<string | null>(null);
+  const unblockRef = useRef<(() => void) | null>(null);
+  const confirmedRef = useRef(false);
+
+  // Handle browser back/forward and navigation
+  useEffect(() => {
+    if (hasUnsavedChanges) {
+      unblockRef.current = history.block((nextLocation) => {
+        // If we've already confirmed, allow navigation
+        if (confirmedRef.current) {
+          confirmedRef.current = false;
+          return true;
+        }
+
+        // If navigating to the same location, allow it
+        if (nextLocation.pathname === location.pathname) {
+          return true;
+        }
+
+        // Show modal and store pending location
+        setPendingLocation(nextLocation.pathname + nextLocation.search);
+        setShowModal(true);
+        return false;
+      });
+    } else {
+      // No unsaved changes, remove blocker
+      if (unblockRef.current) {
+        unblockRef.current();
+        unblockRef.current = null;
+      }
+    }
+
+    return () => {
+      if (unblockRef.current) {
+        unblockRef.current();
+        unblockRef.current = null;
+      }
+    };
+  }, [hasUnsavedChanges, history, location]);
+
+  const handleSave = useCallback(async () => {
+    try {
+      await onSave();
+      setShowModal(false);
+      if (pendingLocation) {
+        confirmedRef.current = true;
+        history.push(pendingLocation);
+        setPendingLocation(null);
+      }
+    } catch (error) {
+      // If save fails, keep the modal open
+      console.error('Failed to save changes:', error);
+    }
+  }, [onSave, pendingLocation, history]);
+
+  const handleDiscard = useCallback(() => {
+    setShowModal(false);
+    if (pendingLocation) {
+      confirmedRef.current = true;
+      history.push(pendingLocation);
+      setPendingLocation(null);
+    }
+  }, [pendingLocation, history]);
+
+  const handleHide = useCallback(() => {
+    setShowModal(false);
+    setPendingLocation(null);
+  }, []);
+
+  // Handle clicks on navigation links
+  useEffect(() => {
+    if (!hasUnsavedChanges) return;
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const link = target.closest('a[href]') as HTMLAnchorElement;
+
+      if (!link) return;
+
+      const href = link.getAttribute('href');
+      if (!href) return;
+
+      // Check if it's an internal navigation link
+      if (href.startsWith('/') && !href.startsWith('//')) {
+        // Prevent default navigation
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Show modal with pending location
+        setPendingLocation(href);
+        setShowModal(true);
+      }
+    };
+
+    document.addEventListener('click', handleClick, true);
+    return () => {
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [hasUnsavedChanges]);
+
+  return {
+    showModal,
+    handleSave,
+    handleDiscard,
+    handleHide,
+  };
+}


### PR DESCRIPTION
### SUMMARY

Previously, when users make changes on their current dashboard/chart view, they may navigate away without saving any changes. They might click to a new section, by accident or have forgotten that their changes were not manually saved. By implementing a confirmation dialog, users are alerted about potential progress loss and can reconsider their actions.

### BEFORE/AFTER ANIMATED GIF

#### Before:

https://drive.google.com/file/d/1-cO8ZRxi4_aF389kgWdat1adn60Fpx9N/view?usp=sharing

#### After:

https://drive.google.com/file/d/1tAQeVBVKp-ZRDnH9NTMspb1FEregsVqM/view?usp=sharing

### TESTING INSTRUCTIONS

#### Manually:

- Dashboard and Explore (Chart):
   1. Navigate to a dashboard view 
   2. Make some modifications
   3. Click to navigate to another section
   4. Verify popup appears with "Save" and "Discard" options
   5. Click "Save" and verify the changes are saved
   6. Repeat steps (i-iv) and click "Discard" to verify navigation proceeds without saving
   7. Repeat steps (i-iv) and click "X" or outside. Verify that the previous state exists. 
  
#### Automated:

```
cd superset-frontend
npm run test -- src/components/UnsavedChangesModal/UnsavedChangesModal.test.tsx
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fix #20 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API